### PR TITLE
fix: Update deployment command in Cloudflare Pages configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,4 +35,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           wranglerVersion: '3'
-          command: pages deploy apps/slide/dist --project-name=happyo-kun
+          command: deploy


### PR DESCRIPTION
## 📋 Summary
Updated the Cloudflare Pages deployment command to simplify the deployment process by removing specific project name and dist path parameters.

## 🔄 Behavior Changes

### Before
The deployment workflow used a complex command with specific project name and dist path:
```
command: pages deploy apps/slide/dist --project-name=happyo-kun
```

### After
Simplified deployment command that relies on wrangler.toml configuration:
```
command: deploy
```

## 📝 Changes Overview
- Updated `.github/workflows/deploy.yml` to use simplified `deploy` command
- Removed explicit `--project-name` and dist path parameters
- Configuration now relies on wrangler.toml settings for project configuration

## ⚠️ Important Notes
- This change assumes that wrangler.toml is properly configured with the correct project settings
- The deployment should work seamlessly as the wrangler configuration contains the necessary project details
- This simplification makes the workflow more maintainable and follows Wrangler CLI best practices