### PR TITLE
fix: Remove unnecessary redirects file after build

### DIFF
--- a/apps/slide/package.json
+++ b/apps/slide/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "slidev build",
+    "build": "slidev build  && rm ./dist/_redirects",
     "dev": "slidev --open",
     "export": "slidev export"
   },

--- a/apps/slide/vite.config.ts
+++ b/apps/slide/vite.config.ts
@@ -8,10 +8,4 @@ export default defineConfig({
         : 'http://localhost:8788/api'
     )
   },
-  slidev: {
-    build: {
-      out: 'dist',
-      redirects: false
-    }
-  }
 })


### PR DESCRIPTION
## 📋 Summary
Remove the `_redirects` file generated by Slidev after the build process to prevent conflicts with Cloudflare Pages deployment configuration.

## 🔄 Behavior Changes

### Before
- Slidev build would generate a `_redirects` file in the dist directory
- This could potentially conflict with Cloudflare Pages' own routing configuration

### After
- Build script now explicitly removes the `_redirects` file after Slidev build completes
- Cleaner build output without conflicting redirect configurations

## 📝 Changes Overview
- Updated build script in `apps/slide/package.json` to remove `_redirects` file post-build
- Removed Slidev-specific redirect configuration from `vite.config.ts`
- Simplified Vite configuration by removing unnecessary build options

## ⚠️ Important Notes
- This change ensures compatibility with Cloudflare Pages deployment
- No impact on development workflow or functionality
- Build output will be cleaner without conflicting redirect files

🤖 Generated with [Claude Code](https://claude.ai/code)